### PR TITLE
Update SBATCH job parameters

### DIFF
--- a/hpc_greene_submit_jobs.sh
+++ b/hpc_greene_submit_jobs.sh
@@ -2,8 +2,8 @@
 #
 #SBATCH --job-name=sampledata
 #SBATCH --nodes=1
-#SBATCH --cpus-per-task=32
-#SBATCH --mem=20g
+#SBATCH --cpus-per-task=30
+#SBATCH --mem=32g
 #SBATCH --time=48:00:00
 #SBATCH --output=/scratch/%u/logs/out.txt # Define output log location
 #SBATCH --error=/scratch/%u/logs/err.txt # and the error logs for when it inevitably crashes


### PR DESCRIPTION
Lower the number of CPUs 32 -> 30 to be able to run on nodes with only 32 cpus.
Test runs with 64 GB of memory allocated show that it uses ~19-20 GB, so increase it to 32 GB to be safe, but not to overkill 

- [ ] it.

We could probably lower also the requested time to 24hrs or even less...