### PR TITLE
BF: Avoid error if "CLUSTER" variable is undefined by adding `-empty`

### DIFF
--- a/subroutines/utils.sh
+++ b/subroutines/utils.sh
@@ -1,5 +1,5 @@
 function on_cluster() {
-	if [[ "$CLUSTER" == "GREENE" ]]; then
+	if [[ "${CLUSTER-empty}" == "GREENE" ]]; then
 		echo TRUE
 	else
 		echo FALSE


### PR DESCRIPTION
In `utils.sh`