### PR TITLE
Update preprocessing tools versions

### DIFF
--- a/s2_add_to_bids.sh
+++ b/s2_add_to_bids.sh
@@ -22,11 +22,11 @@ userID=$(id -u):$(id -g)
 
 
 # Run the docker!
-container_run --name BIDSvalidation_container \
-           --user $userID \
-           --rm \
-           --volume $STUDY_DIR:/data:ro \
-           bids/validator \
-               /data \
+container_run \
+	   $STUDY_DIR:/data:ro \
+	   $STUDY_DIR:/ignore:ro \
+	   bids/validator:v1.7.2 \
+           ${SINGULARITY_PULLFOLDER}/validator_v1.7.2.sif \
+               "/data" \
            > ${logFolder}/bids-validator_report.txt 2>&1  
            #>> ${STUDY_DIR}/derivatives/bids-validator_report.txt 2>&1


### PR DESCRIPTION
Updates:

 * `bids/validator`: `1.4.3` -> `v1.7.2`
 * `poldracklab/fmriprep:1.4.1` -> `nipreps/fmriprep:20.2.1`

Also:

 - skip the BIDS validation in `pydeface` and `fmriprep` since they use an old version of the validator, while `cbinyu/heudiconv` uses a newer version of the BIDS format (`1.4.1`).  This is OK becuse we already run the (newest version of the) validator right after conversion, so we know the data is BIDS compliant.
 - use a newer version of the cbi heuristic which simplifies filenames a bit. This is the new "official" cbi heuristic file.
 - use `container_run` syntax in `s2_add_to_bids.sh`